### PR TITLE
Ksm annotations

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -2,20 +2,20 @@ apiVersion: v2
 name: kube-state-metrics
 description: Install kube-state-metrics to generate and expose cluster-level metrics
 keywords:
-- metric
-- monitoring
-- prometheus
-- kubernetes
+  - metric
+  - monitoring
+  - prometheus
+  - kubernetes
 type: application
-version: 5.2.0
+version: 5.3.0
 appVersion: 2.8.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
-- https://github.com/kubernetes/kube-state-metrics/
+  - https://github.com/kubernetes/kube-state-metrics/
 maintainers:
-- name: tariq1890
-  email: tariq.ibrahim@mulesoft.com
-- name: mrueg
-  email: manuel@rueg.eu
-- name: dotdc
-  email: david@0xdc.me
+  - name: tariq1890
+    email: tariq.ibrahim@mulesoft.com
+  - name: mrueg
+    email: manuel@rueg.eu
+  - name: dotdc
+    email: david@0xdc.me

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -9,6 +9,10 @@ metadata:
   {{- with .Values.prometheus.monitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  annotations:
+  {{- with .Values.prometheus.monitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   {{- with .Values.prometheus.monitor.targetLabels }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -54,7 +54,8 @@ service:
   annotations: {}
 
 ## Additional labels to add to all resources
-customLabels: {}
+customLabels:
+  {}
   # app: kube-state-metrics
 
 ## Override selector labels
@@ -103,7 +104,8 @@ kubeRBACProxy:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
 
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -117,7 +119,8 @@ kubeRBACProxy:
 
   ## volumeMounts enables mounting custom volumes in rbac-proxy containers
   ## Useful for TLS certificates and keys
-  volumeMounts: []
+  volumeMounts:
+    []
     # - mountPath: /etc/tls
     #   name: kube-rbac-proxy-tls
     #   readOnly: true
@@ -139,6 +142,7 @@ serviceAccount:
 prometheus:
   monitor:
     enabled: false
+    annotations: {}
     additionalLabels: {}
     namespace: ""
     jobLabel: ""
@@ -176,7 +180,8 @@ prometheus:
     ## Secret to mount to read bearer token for scraping targets. The secret needs
     ## to be in the same namespace as the service monitor and accessible by the
     ## Prometheus Operator
-    bearerTokenSecret: {}
+    bearerTokenSecret:
+      {}
       # name: secret-name
       # key:  key-name
     tlsConfig: {}
@@ -186,7 +191,8 @@ prometheus:
 ##
 podSecurityPolicy:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     ## Specify pod annotations
     ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
     ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -264,7 +270,8 @@ metricDenylist: []
 # label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'.
 # A single '*' can be provided per resource instead to allow any labels, but that has
 # severe performance implications (Example: '=pods=[*]').
-metricLabelsAllowlist: []
+metricLabelsAllowlist:
+  []
   # - namespaces=[k8s-label-1,k8s-label-n]
 
 # Comma-separated list of Kubernetes annotations keys that will be used in the resource'
@@ -273,7 +280,8 @@ metricLabelsAllowlist: []
 # annotation keys you would like to allow for them (Example: '=namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...)'.
 # A single '*' can be provided per resource instead to allow any annotations, but that has
 # severe performance implications (Example: '=pods=[*]').
-metricAnnotationsAllowList: []
+metricAnnotationsAllowList:
+  []
   # - pods=[k8s-annotation-1,k8s-annotation-n]
 
 # Available collectors for kube-state-metrics.
@@ -330,7 +338,8 @@ namespacesDenylist: ""
 ##
 namespaceOverride: ""
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -372,9 +381,9 @@ verticalPodAutoscaler:
   # memory: 100Mi
 
   # updatePolicy:
-    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
-    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
-    # updateMode: Auto
+  # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+  # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+  # updateMode: Auto
 
 # volumeMounts are used to add custom volume mounts to deployment.
 # See example below


### PR DESCRIPTION
#### What this PR does / why we need it
This PR introduces the `annotations` metadata in the `ServiceMonitor` object. It is needed in case users want to add extra annotations to the object. For example, when using ArgoCD, you need to add extra [annotations ](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types) for more `SyncOptions`


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
